### PR TITLE
複製されたオブジェクトの位置をわずかにずらすスクリプトを追加

### DIFF
--- a/Assets/Scripts/object_validator.cs
+++ b/Assets/Scripts/object_validator.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class object_validator : MonoBehaviour
+{
+    // 一度だけOnValidate()内でオブジェクトの重複チェックを行う
+    private bool hasBeenCheckedPos = false;
+
+    void OnValidate()
+    {
+        if (hasBeenCheckedPos)
+            return;
+
+        // 今のところ親オブジェクトにぶら下がっているもの同士をチェックする
+        if (transform.parent)
+        {
+            Vector3 newPos = transform.position;
+
+            int i = 0, siblingCount = transform.parent.childCount;
+
+            while (i < siblingCount)
+            {
+                Transform child = transform.parent.GetChild(i);
+
+                Debug.Log(child.position);
+
+                if (child.GetInstanceID() != transform.GetInstanceID())
+                {
+                    // [TODO] 本当はコリジョンの大きさなども見るべき
+                    if (child.transform.position == newPos
+                        && child.transform.rotation == transform.rotation
+                        && child.transform.localScale == transform.localScale)
+                    {
+                        newPos += new Vector3(0.2f, 0f, 0.2f);
+                        i = 0;      // Siblingチェックを最初からやり直す.
+                        continue;
+                    }
+                }
+
+                i++;
+            }
+
+            transform.position = newPos;
+        }
+
+        hasBeenCheckedPos = true;
+    }
+}

--- a/Assets/Scripts/object_validator.cs.meta
+++ b/Assets/Scripts/object_validator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87750551abbb5d748a81990182a45990
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
複製されたオブジェクトの位置をわずかにずらすスクリプト object_validator を追加しました。
オブジェクトが新規追加されたときにも OnValidate がコールバックされることを利用して、「１回だけ」、ノードグラフ上のSiblingにあたるオブジェクトをなめて、位置、回転、スケールが同じであれば複製物とみなして位置をずらします。
ただし、連続ペーストを行うと、ずらした位置にもオブジェクトが重なることになるので、新しい位置を決めたらループをやり直しています。もうちょっと整理されたリストがあれば効率化できるかも。

このobject_validatorをすべてのオブジェクトに貼り付けなければいけません。sound.csに仕込むことも考えましたが、soundが入ってないオブジェクトもあるため、独立したCSファイルとしました。